### PR TITLE
fake-redux-store POC

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,25 +1,39 @@
-import React from "react";
+import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import { configureStore } from "@reduxjs/toolkit";
 import rootReducer from "./reducers";
 import { Provider } from "react-redux";
 import "./styles.css";
+import { fakeReduxStore } from "../fake-redux-store";
 
 const store = configureStore({ reducer: rootReducer });
 
 function AppContainer() {
+  const [fake, setFake] = useState(false);
+  const StoreProvider = fake ? FakeStoreProvider : RealStoreProvider;
   return (
     <React.StrictMode>
-      <RealStoreProvider store={store}>
+      <label>
+        <input
+          type="checkbox"
+          checked={fake}
+          onChange={e => setFake(e.target.checked)}
+        />{" "}
+        Use fake store
+      </label>
+      <StoreProvider store={store}>
         <App />
-      </RealStoreProvider>
+      </StoreProvider>
     </React.StrictMode>
   );
 }
 
 function RealStoreProvider({ children }) {
   return <Provider store={store}>{children}</Provider>;
+}
+function FakeStoreProvider({ children }) {
+  return <Provider store={fakeReduxStore}>{children}</Provider>;
 }
 
 const rootElement = document.getElementById("root");

--- a/src/fake-redux-store/index.js
+++ b/src/fake-redux-store/index.js
@@ -7,3 +7,7 @@ export const fakeReduxStore = createStore(() => FAKE_STATE);
 export function isFakeState(state) {
   return state.__FAKE_REDUX_STORE__;
 }
+
+export function provideFakeSelectorResult(selector, fakeResult) {
+  return state => (isFakeState(state) ? fakeResult : selector(state));
+}

--- a/src/fake-redux-store/index.js
+++ b/src/fake-redux-store/index.js
@@ -1,13 +1,23 @@
 import { createStore } from "redux";
 
-export const FAKE_STATE = { __FAKE_REDUX_STORE__: true };
+const FAKE_STATE = { __FAKE_REDUX_STORE__: true };
 
+/**
+ * Use this store in tests or storybooks.
+ */
 export const fakeReduxStore = createStore(() => FAKE_STATE);
 
+/**
+ * Checks if the store’s state belongs to the `fakeReduxStore`.
+ */
 export function isFakeState(state) {
   return state.__FAKE_REDUX_STORE__;
 }
 
+/**
+ * Wrap a Redux selector with this higher-order selector to make
+ * it return `fakeResult` when used with `fakeReduxStore`.
+ */
 export function provideFakeSelectorResult(selector, fakeResult) {
   return state => (isFakeState(state) ? fakeResult : selector(state));
 }

--- a/src/fake-redux-store/index.js
+++ b/src/fake-redux-store/index.js
@@ -1,0 +1,9 @@
+import { createStore } from "redux";
+
+export const FAKE_STATE = { __FAKE_REDUX_STORE__: true };
+
+export const fakeReduxStore = createStore(() => FAKE_STATE);
+
+export function isFakeState(state) {
+  return state.__FAKE_REDUX_STORE__;
+}

--- a/src/features/userSession.js
+++ b/src/features/userSession.js
@@ -1,5 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { useSelector } from "react-redux";
+import { provideFakeSelectorResult } from "../fake-redux-store";
 
 const { reducer } = createSlice({
   name: "userSession",
@@ -8,7 +9,10 @@ const { reducer } = createSlice({
   }
 });
 
-const selectCurrentUserId = state => state.userSession.currentUserId;
+const selectCurrentUserId = provideFakeSelectorResult(
+  state => state.userSession.currentUserId,
+  "fakeuser"
+);
 
 export function useCurrentUserId() {
   return useSelector(selectCurrentUserId);

--- a/src/features/users.js
+++ b/src/features/users.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { useSelector } from "react-redux";
 import { memoize } from "lodash";
+import { provideFakeSelectorResult } from "../fake-redux-store";
 
 const { reducer } = createSlice({
   name: "users",
@@ -14,7 +15,11 @@ const { reducer } = createSlice({
   }
 });
 
-const selectUserById = memoize(userId => state => state.users[userId]);
+const selectUserById = memoize(userId =>
+  provideFakeSelectorResult(state => state.users[userId], {
+    name: `User ${userId}`
+  })
+);
 
 export function useUser(userId) {
   return useSelector(selectUserById(userId));


### PR DESCRIPTION
## Problems

We want to be able to test components where its descendants require a Redux store without having to separate them into container components and presentational components.

In this POC, we make our store selectors smart enough to detect if a real Redux store is not present, and provide a fake data instead. This is done through the `fake-redux-store` module.

## Preview

- **Before**

  https://codesandbox.io/s/github/dtinth/fake-redux-store-poc/tree/master

- **After**

  https://codesandbox.io/s/github/dtinth/fake-redux-store-poc/tree/csb-1583233163262